### PR TITLE
Fix formatting of includes list in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=BLE functions for ESP32
 category=Communication
 url=https://github.com/nkolban/ESP32_BLE_Arduino
 architectures=esp32
-includes=BLE.h BLEUtils.h BLEScan.h BLEAdvertisedDevice.h
+includes=BLE.h,BLEUtils.h,BLEScan.h,BLEAdvertisedDevice.h
 dot_a_linkage=true


### PR DESCRIPTION
The list of files in the `includes` field of library.properties must be comma separated. The previous format caused **Sketch > Include Library > ESP32 BLE Arduino** to add the following erroneous line to the sketch:
```arduino
#include <BLE.h BLEUtils.h BLEScan.h BLEAdvertisedDevice.h>
```
Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format