### PR TITLE
fix clearing of vectors and maps

### DIFF
--- a/src/BLEClient.cpp
+++ b/src/BLEClient.cpp
@@ -283,7 +283,7 @@ std::map<std::string, BLERemoteService*>* BLEClient::getServices() {
  * and will culminate with an ESP_GATTC_SEARCH_CMPL_EVT when all have been received.
  */
 	ESP_LOGD(LOG_TAG, ">> getServices");
-	m_servicesMap.empty();
+	m_servicesMap.clear();
 	esp_err_t errRc = esp_ble_gattc_search_service(
 		getGattcIf(),
 		getConnId(),

--- a/src/BLERemoteService.cpp
+++ b/src/BLERemoteService.cpp
@@ -196,7 +196,7 @@ void BLERemoteService::removeCharacteristics() {
 	for (auto &myPair : m_characteristicMap) {
 	   delete myPair.second;
 	}
-	m_characteristicMap.empty();
+	m_characteristicMap.clear();
 } // removeCharacteristics
 
 

--- a/src/BLEScan.cpp
+++ b/src/BLEScan.cpp
@@ -204,7 +204,7 @@ BLEScanResults BLEScan::start(uint32_t duration) {
 
 	m_semaphoreScanEnd.take("start");
 
-	m_scanResults.m_vectorAdvertisedDevices.empty();
+	m_scanResults.m_vectorAdvertisedDevices.clear();
 
 	esp_err_t errRc = ::esp_ble_gap_set_scan_params(&m_scan_params);
 


### PR DESCRIPTION
I am using your library to do multiple scans in an defined interval and ran into a lot of crashes due to constantly decreasing free memory.

When looking into your code I found out you are using `.empty()` instead of `.clear()` for some vectors and maps. Changing this fixed the memory problems.