### PR TITLE
Multiple Client Support + registerForNotify callback change

### DIFF
--- a/src/BLEClient.cpp
+++ b/src/BLEClient.cpp
@@ -44,12 +44,13 @@
  */
 static const char* LOG_TAG = "BLEClient";
 
-BLEClient::BLEClient() {
+BLEClient::BLEClient(uint16_t appId) {
 	m_pClientCallbacks = nullptr;
 	m_conn_id          = 0;
 	m_gattc_if         = 0;
 	m_haveServices     = false;
 	m_isConnected      = false;  // Initially, we are flagged as not connected.
+	m_app_id					 = appId;
 } // BLEClient
 
 
@@ -87,6 +88,7 @@ void BLEClient::clearServices() {
  * @return True on success.
  */
 bool BLEClient::connect(BLEAddress address) {
+	// register with the BLEDevice singleton
 	ESP_LOGD(LOG_TAG, ">> connect(%s)", address.toString().c_str());
 
 // We need the connection handle that we get from registering the application.  We register the app
@@ -95,7 +97,7 @@ bool BLEClient::connect(BLEAddress address) {
 
 	clearServices(); // Delete any services that may exist.
 
-	esp_err_t errRc = ::esp_ble_gattc_app_register(0);
+	esp_err_t errRc = ::esp_ble_gattc_app_register(m_app_id);
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_ble_gattc_app_register: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 		return false;
@@ -110,7 +112,6 @@ bool BLEClient::connect(BLEAddress address) {
 	errRc = ::esp_ble_gattc_open(
 		getGattcIf(),
 		*getPeerAddress().getNative(), // address
-		BLE_ADDR_TYPE_PUBLIC,          // Note: This was added on 2018-04-03 when the latest ESP-IDF was detected to have changed the signature.
 		1                              // direct connection
 	);
 	if (errRc != ESP_OK) {
@@ -130,13 +131,13 @@ bool BLEClient::connect(BLEAddress address) {
  */
 void BLEClient::disconnect() {
 	ESP_LOGD(LOG_TAG, ">> disconnect()");
+	// unregister from the BLEDevice singleton
 	esp_err_t errRc = ::esp_ble_gattc_close(getGattcIf(), getConnId());
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_ble_gattc_close: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 		return;
 	}
 	esp_ble_gattc_app_unregister(getGattcIf());
-	m_peerAddress = BLEAddress("00:00:00:00:00:00");
 	ESP_LOGD(LOG_TAG, "<< disconnect()");
 } // disconnect
 

--- a/src/BLEClient.h
+++ b/src/BLEClient.h
@@ -20,8 +20,6 @@
 #include "BLEService.h"
 #include "BLEAddress.h"
 
-static uint16_t app_id_counter = 0;
-
 class BLERemoteService;
 class BLEClientCallbacks;
 

--- a/src/BLEClient.h
+++ b/src/BLEClient.h
@@ -20,6 +20,8 @@
 #include "BLEService.h"
 #include "BLEAddress.h"
 
+static uint16_t app_id_counter = 0;
+
 class BLERemoteService;
 class BLEClientCallbacks;
 
@@ -28,10 +30,10 @@ class BLEClientCallbacks;
  */
 class BLEClient {
 public:
-	BLEClient();
+	BLEClient(uint16_t app_id);
 	~BLEClient();
 
-	bool                                       connect(BLEAddress address);   // Connect to the remote BLE Server
+	bool                                       connect(BLEAddress address);		// Connect to the remote BLE Server
 	void                                       disconnect();                  // Disconnect from the remote BLE Server
 	BLEAddress                                 getPeerAddress();              // Get the address of the remote BLE Server
 	int                                        getRssi();                     // Get the RSSI of the remote BLE Server
@@ -72,6 +74,7 @@ private:
 	esp_gatt_if_t m_gattc_if;
 	bool          m_haveServices;    // Have we previously obtain the set of services from the remote server.
 	bool          m_isConnected;     // Are we currently connected.
+	uint16_t			m_app_id;
 
 	BLEClientCallbacks* m_pClientCallbacks;
 	FreeRTOS::Semaphore m_semaphoreRegEvt        = FreeRTOS::Semaphore("RegEvt");

--- a/src/BLEDescriptor.cpp
+++ b/src/BLEDescriptor.cpp
@@ -155,7 +155,7 @@ void BLEDescriptor::handleGATTServerEvent(
 					(uint32_t)m_pCharacteristic->getService()->getLastCreatedCharacteristic());
 					*/
 			if (m_pCharacteristic != nullptr &&
-					m_bleUUID.equals(BLEUUID(param->add_char_descr.descr_uuid)) &&
+					m_bleUUID.equals(BLEUUID(param->add_char_descr.char_uuid)) &&
 					m_pCharacteristic->getService()->getHandle() == param->add_char_descr.service_handle &&
 					m_pCharacteristic == m_pCharacteristic->getService()->getLastCreatedCharacteristic()) {
 				setHandle(param->add_char_descr.attr_handle);

--- a/src/BLEDevice.cpp
+++ b/src/BLEDevice.cpp
@@ -39,7 +39,9 @@ static const char* LOG_TAG = "BLEDevice";
  */
 BLEServer* BLEDevice::m_pServer = nullptr;
 BLEScan*   BLEDevice::m_pScan   = nullptr;
-BLEClient* BLEDevice::m_pClient = nullptr;
+std::map<uint16_t, BLEClient*> BLEDevice::clients;
+std::map<esp_gatt_if_t, BLEClient*> BLEDevice::connectedClients;
+std::map<std::string, BLEClient*> BLEDevice::connectedClientsAddr;
 bool       initialized          = false;   // Have we been initialized?
 esp_ble_sec_act_t 	BLEDevice::m_securityLevel = (esp_ble_sec_act_t)0;
 BLESecurityCallbacks* BLEDevice::m_securityCallbacks = nullptr;
@@ -49,15 +51,15 @@ uint16_t   BLEDevice::m_localMTU = 23;
  * @brief Create a new instance of a client.
  * @return A new instance of the client.
  */
-/* STATIC */ BLEClient* BLEDevice::createClient() {
+/* STATIC */ BLEClient* BLEDevice::createClient(uint16_t appId) {
 	ESP_LOGD(LOG_TAG, ">> createClient");
 #ifndef CONFIG_GATTC_ENABLE  // Check that BLE GATTC is enabled in make menuconfig
 	ESP_LOGE(LOG_TAG, "BLE GATTC is not enabled - CONFIG_GATTC_ENABLE not defined");
 	abort();
 #endif  // CONFIG_GATTC_ENABLE
-	m_pClient = new BLEClient();
+	clients[appId] = new BLEClient(appId);
 	ESP_LOGD(LOG_TAG, "<< createClient");
-	return m_pClient;
+	return clients[appId];
 } // createClient
 
 
@@ -143,7 +145,20 @@ uint16_t   BLEDevice::m_localMTU = 23;
 	BLEUtils::dumpGattClientEvent(event, gattc_if, param);
 
 	switch(event) {
+		case ESP_GATTC_REG_EVT: {
+			ESP_LOGI(LOG_TAG, "REG_EVT");
+			// get associated client
+			BLEClient* client = clients[(uint16_t)param->reg.app_id];
+
+			// store connected client with interface
+			connectedClients[gattc_if] = client;
+			break;
+		}
 		case ESP_GATTC_CONNECT_EVT: {
+			BLEClient* temp = connectedClients[gattc_if];
+			BLEAddress address = BLEAddress(param->connect.remote_bda);
+			connectedClientsAddr[address.toString()] = temp;
+
 			if(BLEDevice::getMTU() != 23){
 				esp_err_t errRc = esp_ble_gattc_send_mtu_req(gattc_if, param->connect.conn_id);
 				if (errRc != ESP_OK) {
@@ -165,9 +180,8 @@ uint16_t   BLEDevice::m_localMTU = 23;
 
 
 	// If we have a client registered, call it.
-	if (BLEDevice::m_pClient != nullptr) {
-		BLEDevice::m_pClient->gattClientEventHandler(event, gattc_if, param);
-	}
+	BLEClient* client = connectedClients[gattc_if];
+	client->gattClientEventHandler(event, gattc_if, param);
 
 } // gattClientEventHandler
 
@@ -262,8 +276,11 @@ uint16_t   BLEDevice::m_localMTU = 23;
 		BLEDevice::m_pServer->handleGAPEvent(event, param);
 	}
 
-	if (BLEDevice::m_pClient != nullptr) {
-		BLEDevice::m_pClient->handleGAPEvent(event, param);
+	// hardcoded for now because of the remote address dependency
+	if (event == ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT) {
+		BLEAddress address = BLEAddress(param->read_rssi_cmpl.remote_addr);
+		BLEClient* client = connectedClientsAddr[address.toString()];
+		client->handleGAPEvent(event, param);
 	}
 
 	if (BLEDevice::m_pScan != nullptr) {
@@ -314,7 +331,7 @@ uint16_t   BLEDevice::m_localMTU = 23;
  */
 /* STATIC */ std::string BLEDevice::getValue(BLEAddress bdAddress, BLEUUID serviceUUID, BLEUUID characteristicUUID) {
 	ESP_LOGD(LOG_TAG, ">> getValue: bdAddress: %s, serviceUUID: %s, characteristicUUID: %s", bdAddress.toString().c_str(), serviceUUID.toString().c_str(), characteristicUUID.toString().c_str());
-	BLEClient *pClient = createClient();
+	BLEClient *pClient = createClient(DEFAULT_APP_ID);
 	pClient->connect(bdAddress);
 	std::string ret = pClient->getValue(serviceUUID, characteristicUUID);
 	pClient->disconnect();
@@ -444,7 +461,7 @@ uint16_t   BLEDevice::m_localMTU = 23;
  */
 /* STATIC */ void BLEDevice::setValue(BLEAddress bdAddress, BLEUUID serviceUUID, BLEUUID characteristicUUID, std::string value) {
 	ESP_LOGD(LOG_TAG, ">> setValue: bdAddress: %s, serviceUUID: %s, characteristicUUID: %s", bdAddress.toString().c_str(), serviceUUID.toString().c_str(), characteristicUUID.toString().c_str());
-	BLEClient *pClient = createClient();
+	BLEClient *pClient = createClient(DEFAULT_APP_ID);
 	pClient->connect(bdAddress);
 	pClient->setValue(serviceUUID, characteristicUUID, value);
 	pClient->disconnect();

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -21,13 +21,15 @@
 #include "BLEScan.h"
 #include "BLEAddress.h"
 
+#define DEFAULT_APP_ID 0
+
 /**
  * @brief %BLE functions.
  */
 class BLEDevice {
 public:
 
-	static BLEClient*  createClient();    // Create a new BLE client.
+	static BLEClient*  createClient(uint16_t appId);    // Create a new BLE client.
 	static BLEServer*  createServer();    // Cretae a new BLE server.
 	static BLEAddress  getAddress();      // Retrieve our own local BD address.
 	static BLEScan*    getScan();         // Get the scan object
@@ -47,7 +49,9 @@ public:
 private:
 	static BLEServer *m_pServer;
 	static BLEScan   *m_pScan;
-	static BLEClient *m_pClient;
+	static std::map<uint16_t, BLEClient*> clients;
+	static std::map<esp_gatt_if_t, BLEClient*> connectedClients;
+	static std::map<std::string, BLEClient*> connectedClientsAddr;
 	static esp_ble_sec_act_t 	m_securityLevel;
 	static BLESecurityCallbacks* m_securityCallbacks;
 	static uint16_t		m_localMTU;

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -49,9 +49,9 @@ public:
 private:
 	static BLEServer *m_pServer;
 	static BLEScan   *m_pScan;
-	static std::map<uint16_t, BLEClient*> clients;
-	static std::map<esp_gatt_if_t, BLEClient*> connectedClients;
-	static std::map<std::string, BLEClient*> connectedClientsAddr;
+	static std::map<uint16_t, BLEClient*> m_clients;
+	static std::map<esp_gatt_if_t, BLEClient*> m_connectedClients;
+	static std::map<std::string, BLEClient*> m_connectedClientsAddr;
 	static esp_ble_sec_act_t 	m_securityLevel;
 	static BLESecurityCallbacks* m_securityCallbacks;
 	static uint16_t		m_localMTU;

--- a/src/BLENotifier.h
+++ b/src/BLENotifier.h
@@ -1,0 +1,6 @@
+#include "BLERemoteCharacteristic.h"
+
+class BLENotifier {
+	public:
+		virtual void onNotify(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify)=0;
+};

--- a/src/BLERemoteCharacteristic.cpp
+++ b/src/BLERemoteCharacteristic.cpp
@@ -471,10 +471,10 @@ std::string BLERemoteCharacteristic::readValue() {
  * @return N/A.
  */
 void BLERemoteCharacteristic::registerForNotify(
-		Notifier* classToNotify) {
+		Notifier* objectToNotify) {
 	ESP_LOGD(LOG_TAG, ">> registerForNotify(): %s", toString().c_str());
 
-	toNotify = classToNotify;   // Save the notification callback.
+	toNotify = objectToNotify;   // Save the notification callback.
 
 	m_semaphoreRegForNotifyEvt.take("registerForNotify");
 

--- a/src/BLERemoteCharacteristic.cpp
+++ b/src/BLERemoteCharacteristic.cpp
@@ -43,7 +43,7 @@ BLERemoteCharacteristic::BLERemoteCharacteristic(
 	m_uuid           = uuid;
 	m_charProp       = charProp;
 	m_pRemoteService = pRemoteService;
-	m_notifyCallback = nullptr;
+	toNotify = nullptr;
 
 	retrieveDescriptors(); // Get the descriptors for this characteristic
 	ESP_LOGD(LOG_TAG, "<< BLERemoteCharacteristic");
@@ -170,9 +170,9 @@ void BLERemoteCharacteristic::gattClientEventHandler(
 			if (evtParam->notify.handle != getHandle()) {
 				break;
 			}
-			if (m_notifyCallback != nullptr) {
+			if (toNotify != nullptr) {
 				ESP_LOGD(LOG_TAG, "Invoking callback for notification on characteristic %s", toString().c_str());
-				m_notifyCallback(
+				toNotify->onData(
 					this,
 					evtParam->notify.value,
 					evtParam->notify.value_len,
@@ -471,18 +471,14 @@ std::string BLERemoteCharacteristic::readValue() {
  * @return N/A.
  */
 void BLERemoteCharacteristic::registerForNotify(
-		void (*notifyCallback)(
-			BLERemoteCharacteristic* pBLERemoteCharacteristic,
-			uint8_t*                 pData,
-			size_t                   length,
-			bool                     isNotify)) {
+		Notifier* classToNotify) {
 	ESP_LOGD(LOG_TAG, ">> registerForNotify(): %s", toString().c_str());
 
-	m_notifyCallback = notifyCallback;   // Save the notification callback.
+	toNotify = classToNotify;   // Save the notification callback.
 
 	m_semaphoreRegForNotifyEvt.take("registerForNotify");
 
-	if (notifyCallback != nullptr) {   // If we have a callback function, then this is a registration.
+	if (toNotify != nullptr) {   // If we have a callback function, then this is a registration.
 		esp_err_t errRc = ::esp_ble_gattc_register_for_notify(
 			m_pRemoteService->getClient()->getGattcIf(),
 			*m_pRemoteService->getClient()->getPeerAddress().getNative(),

--- a/src/BLERemoteCharacteristic.h
+++ b/src/BLERemoteCharacteristic.h
@@ -19,6 +19,11 @@
 #include "BLEUUID.h"
 #include "FreeRTOS.h"
 
+class Notifier {
+	public:
+		virtual void onData(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify)=0;
+};
+
 class BLERemoteService;
 class BLERemoteDescriptor;
 
@@ -44,11 +49,12 @@ public:
 	uint8_t     readUInt8(void);
 	uint16_t    readUInt16(void);
 	uint32_t    readUInt32(void);
-	void        registerForNotify(void (*notifyCallback)(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify));
+	void        registerForNotify(Notifier* classToNotify);
 	void        writeValue(uint8_t* data, size_t length, bool response = false);
 	void        writeValue(std::string newValue, bool response = false);
 	void        writeValue(uint8_t newValue, bool response = false);
 	std::string toString(void);
+	Notifier* toNotify = nullptr;
 
 private:
 	BLERemoteCharacteristic(uint16_t handle, BLEUUID uuid, esp_gatt_char_prop_t charProp, BLERemoteService* pRemoteService);
@@ -76,7 +82,6 @@ private:
 	FreeRTOS::Semaphore  m_semaphoreRegForNotifyEvt  = FreeRTOS::Semaphore("RegForNotifyEvt");
 	FreeRTOS::Semaphore  m_semaphoreWriteCharEvt     = FreeRTOS::Semaphore("WriteCharEvt");
 	std::string          m_value;
-  void (*m_notifyCallback)(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
 
 	// We maintain a map of descriptors owned by this characteristic keyed by a string representation of the UUID.
 	std::map<std::string, BLERemoteDescriptor*> m_descriptorMap;

--- a/src/BLERemoteCharacteristic.h
+++ b/src/BLERemoteCharacteristic.h
@@ -19,11 +19,6 @@
 #include "BLEUUID.h"
 #include "FreeRTOS.h"
 
-class Notifier {
-	public:
-		virtual void onData(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify)=0;
-};
-
 class BLERemoteService;
 class BLERemoteDescriptor;
 
@@ -49,12 +44,12 @@ public:
 	uint8_t     readUInt8(void);
 	uint16_t    readUInt16(void);
 	uint32_t    readUInt32(void);
-	void        registerForNotify(Notifier* classToNotify);
+	void        registerForNotify(BLENotifier* objectToNotify);
 	void        writeValue(uint8_t* data, size_t length, bool response = false);
 	void        writeValue(std::string newValue, bool response = false);
 	void        writeValue(uint8_t newValue, bool response = false);
 	std::string toString(void);
-	Notifier* toNotify = nullptr;
+	BLENotifier* toNotify = nullptr;
 
 private:
 	BLERemoteCharacteristic(uint16_t handle, BLEUUID uuid, esp_gatt_char_prop_t charProp, BLERemoteService* pRemoteService);


### PR DESCRIPTION
This PR is a POC that has support for two new features:

## Multiple Server Support
By passing an `appId` into `BLEDevice::createClient`, you can now have client connections to multiple servers in the ESP32 application. 

## BLENotifier to replace `registerForNotify` function
Replacement for the requirement of `static void` function for `registerForNotify` by providing a base `BLENotifier` class with a virtual `onNotify` function. This way, your callback can be part of the instantiated object and receive notifications that only pertain to it.

### Caveats
* As mentioned above, this is a POC whipped up together. It does functionally work but does not follow some of the naming conventions. Let me know what you think!
* I've only test connected to two servers. I don't know if there's a hard limitation on number of connections the ESP32 can make.