### PR TITLE
Custom return codes for onWrite to allow for object transfer service

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -230,10 +230,11 @@ void BLECharacteristic::handleGATTServerEvent(
 		// - uint8_t exec_write_flag - Either ESP_GATT_PREP_WRITE_EXEC or ESP_GATT_PREP_WRITE_CANCEL
 		//
 		case ESP_GATTS_EXEC_WRITE_EVT: {
+			esp_gatt_status_t retval = ESP_GATT_OK;
 			if (param->exec_write.exec_write_flag == ESP_GATT_PREP_WRITE_EXEC) {
 				m_value.commit();
 				if (m_pCallbacks != nullptr) {
-					m_pCallbacks->onWrite(this); // Invoke the onWrite callback handler.
+					retval = m_pCallbacks->onWrite(this,param); // Invoke the onWrite callback handler.
 				}
 			} else {
 				m_value.cancel();
@@ -242,7 +243,7 @@ void BLECharacteristic::handleGATTServerEvent(
 			esp_err_t errRc = ::esp_ble_gatts_send_response(
 					gatts_if,
 					param->write.conn_id,
-					param->write.trans_id, ESP_GATT_OK, nullptr);
+					param->write.trans_id, retval, nullptr);
 			if (errRc != ESP_OK) {
 				ESP_LOGE(LOG_TAG, "esp_ble_gatts_send_response: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 			}
@@ -284,6 +285,7 @@ void BLECharacteristic::handleGATTServerEvent(
 // we save the new value.  Next we look at the need_rsp flag which indicates whether or not we need
 // to send a response.  If we do, then we formulate a response and send it.
 			if (param->write.handle == m_handle) {
+				esp_gatt_status_t retval = ESP_GATT_OK;
 				if (param->write.is_prep) {
 					m_value.addPart(param->write.value, param->write.len);
 				} else {
@@ -297,6 +299,11 @@ void BLECharacteristic::handleGATTServerEvent(
 				ESP_LOGD(LOG_TAG, " - Data: length: %d, data: %s", param->write.len, pHexData);
 				free(pHexData);
 
+				if (m_pCallbacks != nullptr && param->write.is_prep != true) {
+					retval = m_pCallbacks->onWrite(this,param); // Invoke the onWrite callback handler.
+				}
+
+
 				if (param->write.need_rsp) {
 					esp_gatt_rsp_t rsp;
 
@@ -309,15 +316,11 @@ void BLECharacteristic::handleGATTServerEvent(
 					esp_err_t errRc = ::esp_ble_gatts_send_response(
 							gatts_if,
 							param->write.conn_id,
-							param->write.trans_id, ESP_GATT_OK, &rsp);
+							param->write.trans_id, retval, &rsp);
 					if (errRc != ESP_OK) {
 						ESP_LOGE(LOG_TAG, "esp_ble_gatts_send_response: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 					}
 				} // Response needed
-
-				if (m_pCallbacks != nullptr && param->write.is_prep != true) {
-					m_pCallbacks->onWrite(this); // Invoke the onWrite callback handler.
-				}
 			} // Match on handles.
 			break;
 		} // ESP_GATTS_WRITE_EVT
@@ -780,7 +783,6 @@ void BLECharacteristicCallbacks::onRead(BLECharacteristic *pCharacteristic) {
 	ESP_LOGD("BLECharacteristicCallbacks", "<< onRead");
 } // onRead
 
-
 /**
  * @brief Callback function to support a write request.
  * @param [in] pCharacteristic The characteristic that is the source of the event.
@@ -788,6 +790,17 @@ void BLECharacteristicCallbacks::onRead(BLECharacteristic *pCharacteristic) {
 void BLECharacteristicCallbacks::onWrite(BLECharacteristic *pCharacteristic) {
 	ESP_LOGD("BLECharacteristicCallbacks", ">> onWrite: default");
 	ESP_LOGD("BLECharacteristicCallbacks", "<< onWrite");
+} // onWrite
+
+/**
+ * @brief Callback function to support a write request with custom GATTS status code... can be used to implement object transfer protocol
+ * @param [out] esp_gatt_status_t GATTS_STATUS code in the response
+ * @param [in] pCharacteristic The characteristic that is the source of the event.
+ * @param [in] param the context of the write
+ */
+esp_gatt_status_t BLECharacteristicCallbacks::onWrite(BLECharacteristic* pCharacteristic, esp_ble_gatts_cb_param_t* param) {
+	this->onRead(pCharacteristic);
+	return ESP_GATT_OK;
 } // onWrite
 
 #endif /* CONFIG_BT_ENABLED */

--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -21,7 +21,6 @@
 class BLEService;
 class BLEDescriptor;
 class BLECharacteristicCallbacks;
-class BLEComplexCharacteristicCallbacks;
 
 /**
  * @brief A management structure for %BLE descriptors.

--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -21,6 +21,7 @@
 class BLEService;
 class BLEDescriptor;
 class BLECharacteristicCallbacks;
+class BLEComplexCharacteristicCallbacks;
 
 /**
  * @brief A management structure for %BLE descriptors.
@@ -135,6 +136,8 @@ public:
 	virtual ~BLECharacteristicCallbacks();
 	virtual void onRead(BLECharacteristic* pCharacteristic);
 	virtual void onWrite(BLECharacteristic* pCharacteristic);
+	virtual esp_gatt_status_t onWrite(BLECharacteristic* pCharacteristic, esp_ble_gatts_cb_param_t* param);
 };
+
 #endif /* CONFIG_BT_ENABLED */
 #endif /* COMPONENTS_CPP_UTILS_BLECHARACTERISTIC_H_ */


### PR DESCRIPTION
I added the ability to return error response codes for onWrite. This is necessary to implement object transfer service. 
Furthermore esp_ble_gatts_cb_param_t* param is forwarded to onWrite. This is necessary to correlate the write request to OACP to the CID of the L2CAP CoC. 

