### PR TITLE
BLERemoteDescriptor fix (required for comms with Nordic Thingy:52)

### DIFF
--- a/src/BLERemoteDescriptor.cpp
+++ b/src/BLERemoteDescriptor.cpp
@@ -148,7 +148,7 @@ void BLERemoteDescriptor::writeValue(
 		getHandle(),
 		length,                           // Data length
 		data,                             // Data
-		ESP_GATT_WRITE_TYPE_NO_RSP,
+		response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP,
 		ESP_GATT_AUTH_REQ_NONE
 	);
 	if (errRc != ESP_OK) {


### PR DESCRIPTION
I spent all day yesterday trying to get notifications to work with the Nordic Thingy:52, but didn't succeed.

Fresh day, fresh ideas, and I noticed that the `response` argument to `BLERemoteDescriptor.writeValue()` wasn't being used (it always used `ESP_GATT_WRITE_TYPE_NO_RSP`).

Patched the code, and now it works. Apparently, the Thingy requires this.