### PR TITLE
add ESP_GATTS_SEND_SERVICE_CHANGE_EVT ble utils gatt

### DIFF
--- a/src/BLEUtils.cpp
+++ b/src/BLEUtils.cpp
@@ -1058,6 +1058,9 @@ std::string BLEUtils::gattServerEventTypeToString(esp_gatts_cb_event_t eventType
 	case ESP_GATTS_SET_ATTR_VAL_EVT:
 		return "ESP_GATTS_SET_ATTR_VAL_EVT";
 
+    case ESP_GATTS_SEND_SERVICE_CHANGE_EVT:
+        return "ESP_GATTS_SEND_SERVICE_CHANGE_EVT";
+
 	}
 	return "Unknown";
 } // gattServerEventTypeToString


### PR DESCRIPTION
# why 
I could not build in my environment when using this library.
The reason is  `ESP_GATTS_SEND_SERVICE_CHANGE_EVT` dose not exsist in this switch case.

# what 
add ESP_GATTS_SEND_SERVICE_CHANGE_EVT.
I could build this.