### PR TITLE
App unregistration

### DIFF
--- a/src/BLEServer.cpp
+++ b/src/BLEServer.cpp
@@ -49,6 +49,13 @@ void BLEServer::createApp(uint16_t appId) {
 } // createApp
 
 
+void BLEServer::deleteApp(void) {
+	unregisterApp(m_appId);
+	m_appId = -1;
+	m_gatts_if = -1;
+} // deleteApp
+
+
 /**
  * @brief Create a %BLE Service.
  *
@@ -249,6 +256,13 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
 		} // ESP_GATTS_REG_EVT
 
 
+		// ESP_GATTS_UNREG_EVT
+		// nothing
+		case ESP_GATTS_UNREG_EVT: {
+			m_semaphoreUnregisterAppEvt.give(); // Unlock the mutex waiting for the unregistration of the app.
+			break;
+		} // ESP_GATTS_UNREG_EVT
+
 		// ESP_GATTS_WRITE_EVT - A request to write the value of a characteristic has arrived.
 		//
 		// write:
@@ -293,6 +307,20 @@ void BLEServer::registerApp(uint16_t m_appId) {
 	m_semaphoreRegisterAppEvt.wait("registerApp");
 	ESP_LOGD(LOG_TAG, "<< registerApp");
 } // registerApp
+
+
+/**
+ * @brief Unregister the app.
+ *
+ * @return N/A
+ */
+void BLEServer::unregisterApp(uint16_t i_appId) {
+	ESP_LOGD(LOG_TAG, ">> unregisterApp - %d", i_appId);
+	m_semaphoreUnregisterAppEvt.take("unregisterApp"); // Take the mutex, will be released by ESP_GATTS_REG_EVT event.
+	::esp_ble_gatts_app_unregister(m_gatts_if);
+	m_semaphoreUnregisterAppEvt.wait("unregisterApp");
+	ESP_LOGD(LOG_TAG, "<< unregisterApp");
+} // unregisterApp
 
 
 /**

--- a/src/BLEServer.cpp
+++ b/src/BLEServer.cpp
@@ -43,6 +43,17 @@ BLEServer::BLEServer() {
 } // BLEServer
 
 
+/**
+ * @brief Destruct a %BLE Server
+ *
+ */
+BLEServer::~BLEServer() {
+	if (m_appId != -1 && m_gatts_if != -1) {
+		deleteApp();
+	}
+} // ~BLEServer
+
+
 void BLEServer::createApp(uint16_t appId) {
 	m_appId = appId;
 	registerApp(appId);

--- a/src/BLEServer.h
+++ b/src/BLEServer.h
@@ -98,15 +98,20 @@ private:
   	std::map<uint16_t, conn_status_t> m_connectedServersMap;
 
 	FreeRTOS::Semaphore m_semaphoreRegisterAppEvt 	= FreeRTOS::Semaphore("RegisterAppEvt");
+	FreeRTOS::Semaphore m_semaphoreUnregisterAppEvt = FreeRTOS::Semaphore("UnregisterAppEvt");
 	FreeRTOS::Semaphore m_semaphoreCreateEvt 		= FreeRTOS::Semaphore("CreateEvt");
 	FreeRTOS::Semaphore m_semaphoreOpenEvt   		= FreeRTOS::Semaphore("OpenEvt");
+
 	BLEServiceMap       m_serviceMap;
 	BLEServerCallbacks* m_pServerCallbacks = nullptr;
 
 	void            createApp(uint16_t appId);
+	void            deleteApp(void);
+	uint16_t        getConnId();
 	uint16_t        getGattsIf();
 	void            handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 	void            registerApp(uint16_t);
+	void            unregisterApp(uint16_t);
 }; // BLEServer
 
 

--- a/src/BLEServer.h
+++ b/src/BLEServer.h
@@ -62,6 +62,7 @@ private:
  */
 class BLEServer {
 public:
+	~BLEServer() ;
 	uint32_t        getConnectedCount();
 	BLEService*     createService(const char* uuid);	
 	BLEService*     createService(BLEUUID uuid, uint32_t numHandles=15, uint8_t inst_id=0);


### PR DESCRIPTION
Trying to switch on and off the BLE server, I got errors indicating that the app was already registered. Unfortunately, `BLEDevice::createServer()` creates an app with an ID of zero hardcoded, so a quick hack consisting of changing of app ID wasn't possible without modifying the library code. So I might as well do the cleanest thing, which is to unregister the app, instead of registering another one with a different ID. That's what this simple PR does.