### PR TITLE
Alter library so it can handle multiple service data

### DIFF
--- a/src/BLEAdvertisedDevice.cpp
+++ b/src/BLEAdvertisedDevice.cpp
@@ -29,7 +29,6 @@ BLEAdvertisedDevice::BLEAdvertisedDevice() {
 	m_manufacturerData = "";
 	m_name             = "";
 	m_rssi             = -9999;
-	m_serviceData      = "";
 	m_txPower          = 0;
 	m_pScan            = nullptr;
 
@@ -107,11 +106,23 @@ BLEScan* BLEAdvertisedDevice::getScan() {
 
 
 /**
+ * @brief Get the number of service data.
+ * @return Number of service data discovered.
+ */
+int BLEAdvertisedDevice::getServiceDataCount() {
+	if (m_haveServiceData)
+		return m_serviceDataVector.size();
+	else
+		return 0;
+	
+} //getServiceDataCount
+
+/**
  * @brief Get the service data.
  * @return The ServiceData of the advertised device.
  */
-std::string BLEAdvertisedDevice::getServiceData() {
-	return m_serviceData;
+std::string BLEAdvertisedDevice::getServiceData(int i) {
+	return m_serviceDataVector[i];
 } //getServiceData
 
 
@@ -119,8 +130,8 @@ std::string BLEAdvertisedDevice::getServiceData() {
  * @brief Get the service data UUID.
  * @return The service data UUID.
  */
-BLEUUID BLEAdvertisedDevice::getServiceDataUUID() {
-	return m_serviceDataUUID;
+BLEUUID BLEAdvertisedDevice::getServiceDataUUID(int i) {
+	return m_serviceDataUUIDs[i];
 } // getServiceDataUUID
 
 
@@ -128,8 +139,8 @@ BLEUUID BLEAdvertisedDevice::getServiceDataUUID() {
  * @brief Get the Service UUID.
  * @return The Service UUID of the advertised device.
  */
-BLEUUID BLEAdvertisedDevice::getServiceUUID() {  //TODO Remove it eventually, is no longer useful
-	return m_serviceUUIDs[0];
+BLEUUID BLEAdvertisedDevice::getServiceUUID(int i) {  
+	return m_serviceUUIDs[i];
 } // getServiceUUID
 
 /**
@@ -458,7 +469,7 @@ void BLEAdvertisedDevice::setServiceUUID(BLEUUID serviceUUID) {
  */
 void BLEAdvertisedDevice::setServiceData(std::string serviceData) {
 	m_haveServiceData = true;         // Set the flag that indicates we have service data.
-	m_serviceData     = serviceData;  // Save the service data that we received.
+	m_serviceDataVector.push_back(serviceData); // Save the service data that we received.
 } //setServiceData
 
 
@@ -468,7 +479,8 @@ void BLEAdvertisedDevice::setServiceData(std::string serviceData) {
  */
 void BLEAdvertisedDevice::setServiceDataUUID(BLEUUID uuid) {
 	m_haveServiceData = true;         // Set the flag that indicates we have service data.
-	m_serviceDataUUID = uuid;
+	m_serviceDataUUIDs.push_back(uuid);
+	ESP_LOGD(LOG_TAG, "- addServiceDataUUID(): serviceDataUUID: %s", uuid.toString().c_str());
 } // setServiceDataUUID
 
 
@@ -499,7 +511,9 @@ std::string BLEAdvertisedDevice::toString() {
 		free(pHex);
 	}
 	if (haveServiceUUID()) {
-		ss << ", serviceUUID: " << getServiceUUID().toString();
+		for (int i; i < m_serviceUUIDs.size(); i++) {
+			ss << ", serviceUUID: " << getServiceUUID(i).toString();
+		}
 	}
 	if (haveTXPower()) {
 		ss << ", txPower: " << (int)getTXPower();

--- a/src/BLEAdvertisedDevice.h
+++ b/src/BLEAdvertisedDevice.h
@@ -35,9 +35,10 @@ public:
 	std::string getName();
 	int         getRSSI();
 	BLEScan*    getScan();
-	std::string getServiceData();
-	BLEUUID     getServiceDataUUID();
-	BLEUUID     getServiceUUID();
+	std::string getServiceData(int i);
+	BLEUUID     getServiceDataUUID(int i);
+	BLEUUID     getServiceUUID(int i);
+	int         getServiceDataCount();
 	int8_t      getTXPower();
 	uint8_t* 	getPayload();
 
@@ -91,9 +92,9 @@ private:
 	BLEScan*    m_pScan;
 	int         m_rssi;
 	std::vector<BLEUUID> m_serviceUUIDs;
-	int8_t      m_txPower;
-	std::string m_serviceData;
-	BLEUUID     m_serviceDataUUID;
+	std::vector<BLEUUID> m_serviceDataUUIDs;
+	std::vector<std::string> m_serviceDataVector;
+	int8_t      m_txPower;	
 	uint8_t*	m_payload;
 };
 


### PR DESCRIPTION
This is not very clear in the documentation but I needed to add several AD Structures with the type SERVICE_DATA in one of my project.
In order to get those several service data back with your library I had to change it a little...
Maybe others can benefit from this modification
Fred