### PR TITLE
Don't automatically start BLE Advertising once the previous one has finshed.

### DIFF
--- a/src/BLEAdvertising.cpp
+++ b/src/BLEAdvertising.cpp
@@ -488,12 +488,13 @@ void BLEAdvertising::handleGAPEvent(
 			break;
 		}
 		case ESP_GAP_BLE_ADV_START_COMPLETE_EVT: {
+			ESP_LOGI(LOG_TAG, "Advertising has started");
 			// m_semaphoreSetAdv.give();
 			break;
 		}
 		case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT: {
-			ESP_LOGI(LOG_TAG, "STOP advertising");
-			start();
+			ESP_LOGI(LOG_TAG, "Advertising has stopped");
+			//start();
 			break;
 		}
 		default:

--- a/src/BLEServer.cpp
+++ b/src/BLEServer.cpp
@@ -209,13 +209,11 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
 		// - esp_gatt_conn_reason_t         reason
 		//
 		// If we receive a disconnect event then invoke the callback for disconnects (if one is present).
-		// we also want to start advertising again.
 		case ESP_GATTS_DISCONNECT_EVT: {
 			m_connectedCount--;                          // Decrement the number of connected devices count.
 			if (m_pServerCallbacks != nullptr) {         // If we have callbacks, call now.
 				m_pServerCallbacks->onDisconnect(this);
 			}
-			startAdvertising(); //- do this with some delay from the loop()
 			removePeerDevice(param->disconnect.conn_id, false);
 			break;
 		} // ESP_GATTS_DISCONNECT_EVT


### PR DESCRIPTION
Otherwise you can never stop advertising.
If you want continuous advertising then either a client to the BLEAdvertising should handle that or BLEAdvertising should be configurable to allow that, with the default being non-continuous.