### PR TITLE
Expose length of data buffer

### DIFF
--- a/src/BLECharacteristic.cpp
+++ b/src/BLECharacteristic.cpp
@@ -192,6 +192,14 @@ uint8_t* BLECharacteristic::getData() {
 	return m_value.getData();
 } // getData
 
+/**
+ * @brief Retrieve the current length of the raw data of the characteristic.
+ * @return The length of the current characteristic data in bytes.
+ */
+uint8_t* BLECharacteristic::getLength() {
+	return m_value.getLength();
+} // getLength
+
 
 /**
  * Handle a GATT server event.

--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -62,6 +62,7 @@ public:
 	BLEUUID        getUUID();
 	std::string    getValue();
 	uint8_t*       getData();
+	size_t		   getLength();
 
 	void indicate();
 	void notify(bool is_notification = true);

--- a/src/BLECharacteristic.h
+++ b/src/BLECharacteristic.h
@@ -62,7 +62,7 @@ public:
 	BLEUUID        getUUID();
 	std::string    getValue();
 	uint8_t*       getData();
-	size_t		   getLength();
+	size_t         getLength();
 
 	void indicate();
 	void notify(bool is_notification = true);


### PR DESCRIPTION
Added public member variable getLength to expose the length of the 
underlying data buffer.  

This allows for better error checking when reading the raw buffer.