### PR TITLE
Endianness should be flipped at set AND get

### DIFF
--- a/src/BLEBeacon.cpp
+++ b/src/BLEBeacon.cpp
@@ -34,15 +34,15 @@ std::string BLEBeacon::getData() {
 } // getData
 
 uint16_t BLEBeacon::getMajor() {
-	return m_beaconData.major;
+	return ENDIAN_CHANGE_U16(m_beaconData.major);
 }
 
 uint16_t BLEBeacon::getManufacturerId() {
-	return m_beaconData.manufacturerId;
+	return ENDIAN_CHANGE_U16(m_beaconData.manufacturerId);
 }
 
 uint16_t BLEBeacon::getMinor() {
-	return m_beaconData.minor;
+	return ENDIAN_CHANGE_U16(m_beaconData.minor);
 }
 
 BLEUUID BLEBeacon::getProximityUUID() {


### PR DESCRIPTION
Endianness of major, minor and manufacturerID are swapped upon calling the corresponding set method, but they are not swapped back when calling the get. 

Example code to demonstrate the issue
```
Beacon.setMajor(0xABCD);
Serial.printf("TEST: 0x%02x -- Should be 0x%02x\n",oBeacon.getMajor(),0xABCD);
```

Will print 
```TEST: 0xcdab -- Should be 0xabcd```

This patches re-establishes the original endianness while called the get method. 

