### PR TITLE
Added in Short UUID name to fix blank Name being returned

### DIFF
--- a/src/BLEAdvertisedDevice.cpp
+++ b/src/BLEAdvertisedDevice.cpp
@@ -254,8 +254,12 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t* payload, size_t total_len)
 			free(pHex);
 
 			switch(ad_type) {
-				case ESP_BLE_AD_TYPE_NAME_CMPL: {   // Adv Data Type: 0x09
+				case ESP_BLE_AD_TYPE_NAME_SHORT: {   // Adv Data Type: 0x08
 					setName(std::string(reinterpret_cast<char*>(payload), length));
+					break;
+				}// ESP_BLE_AD_TYPE_NAME_SHORT
+				case ESP_BLE_AD_TYPE_NAME_CMPL: {   // Adv Data Type: 0x09
+					//setName(std::string(reinterpret_cast<char*>(payload), length));
 					break;
 				} // ESP_BLE_AD_TYPE_NAME_CMPL
 

--- a/src/BLEAdvertisedDevice.cpp
+++ b/src/BLEAdvertisedDevice.cpp
@@ -259,7 +259,7 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t* payload, size_t total_len)
 					break;
 				}// ESP_BLE_AD_TYPE_NAME_SHORT
 				case ESP_BLE_AD_TYPE_NAME_CMPL: {   // Adv Data Type: 0x09
-					//setName(std::string(reinterpret_cast<char*>(payload), length));
+					setName(std::string(reinterpret_cast<char*>(payload), length));
 					break;
 				} // ESP_BLE_AD_TYPE_NAME_CMPL
 


### PR DESCRIPTION
The BLEAdvertisedDevice.cpp file wasn't looking at the Short UUID name.