### PR TITLE
HID_BRAILLE_DISPLAY

### DIFF
--- a/src/BLEHIDDevice.h
+++ b/src/BLEHIDDevice.h
@@ -26,6 +26,7 @@
 #define HID_CARD_READER	0x03C6
 #define HID_DIGITAL_PEN	0x03C7
 #define HID_BARCODE		0x03C8
+# define  HID_BRAILLE_DISPLAY 		0x03C9
 
 class BLEHIDDevice {
 public:


### PR DESCRIPTION
23 Braille Display Page (0x41)
Braille display allow visually impaired computer users to read out text using raised pins. The pins are electro-mechanically
activated. These devices also have support for controls that help navigate the computer screen. Typically, braille displays
interface with software known as a screen reader in order to perform this navigation.